### PR TITLE
zipit.sh: Use /bin/sh

### DIFF
--- a/zipit.sh
+++ b/zipit.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/sh
 bitcoin-cli stop
 now=$(date +"%y%m%d")
 sleep 1m


### PR DESCRIPTION
The script does not use any special GNU Bash features, so let's use `#!/bin/sh` in the shebang.